### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/scripts/generate_custom_passive_tracers.py
+++ b/scripts/generate_custom_passive_tracers.py
@@ -30,7 +30,7 @@ try:
     import h5py
     import numpy as np
 except ImportError as e:
-    sys.exit("ERROR - You need to have h5py and numpy. Please install the one you are lacking. The computer says:\n%s" % e)
+    sys.exit("ERROR - You need to have h5py and numpy. Please install the one you are lacking. The computer says:\n{0!s}".format(e))
 
 
 def write_points_to_h5(points, filename):
@@ -49,7 +49,7 @@ def write_points_to_h5(points, filename):
         dpos[...] = pos
         dmi[...] = mi
     except Exception as e:
-        sys.exit("\nERROR\nComputer says:\n%s\n" % e)
+        sys.exit("\nERROR\nComputer says:\n{0!s}\n".format(e))
     finally:
         f.close()
 
@@ -161,7 +161,7 @@ def main():
         with open("3D_paraview.xmf", 'w') as f:
             f.write(xmf)
     except Exception as e:
-        sys.exit("ERROR with writing 3D_paraview.xmf. Computer says:\n%s" % e)
+        sys.exit("ERROR with writing 3D_paraview.xmf. Computer says:\n{0!s}".format(e))
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/swarm_deleter.py
+++ b/scripts/swarm_deleter.py
@@ -88,16 +88,16 @@ def main():
         dont_delete.append(last_available_chpt)
 
     for saved in dont_delete:
-        print "Not deleting materialSwarm.%05d.*" % saved
+        print "Not deleting materialSwarm.{0:05d}.*".format(saved)
 
     for chkpt in checkpoints:
         if chkpt in dont_delete:
             continue
         if test_run:
             print "TEST -",
-        print "Deleting materialSwarm.%05d.*" % chkpt,
+        print "Deleting materialSwarm.{0:05d}.*".format(chkpt),
         if not test_run:
-            dead_files = glob.glob("%s/materialSwarm.%05d.*" % (folder, chkpt))
+            dead_files = glob.glob("{0!s}/materialSwarm.{1:05d}.*".format(folder, chkpt))
             if len(dead_files) == 0:
                 print "- already deleted",
             else:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:OlympusMonds:lithospheric_modelling_recipe?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:OlympusMonds:lithospheric_modelling_recipe?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
